### PR TITLE
draft-05 interop with moq-rs (subscribe / watch endpoint)

### DIFF
--- a/lib/transport/client.ts
+++ b/lib/transport/client.ts
@@ -47,13 +47,13 @@ export class Client {
 		const setup = new Setup.Stream(reader, writer)
 
 		// Send the setup message.
-		await setup.send.client({ versions: [Setup.Version.DRAFT_04], role: this.config.role })
+		await setup.send.client({ versions: [Setup.Version.DRAFT_05], role: this.config.role })
 
 		// Receive the setup message.
 		// TODO verify the SETUP response.
 		const server = await setup.recv.server()
 
-		if (server.version != Setup.Version.DRAFT_04) {
+		if (server.version != Setup.Version.DRAFT_05) {
 			throw new Error(`unsupported server version: ${server.version}`)
 		}
 

--- a/lib/transport/control.ts
+++ b/lib/transport/control.ts
@@ -76,7 +76,7 @@ export interface Subscribe {
 export enum GroupOrder {
 	Publisher = 0x0,
 	Ascending = 0x1,
-	Descending = 0x2
+	Descending = 0x2,
 }
 
 export type Location = LatestGroup | LatestObject | AbsoluteStart | AbsoluteRange

--- a/lib/transport/objects.ts
+++ b/lib/transport/objects.ts
@@ -82,17 +82,17 @@ export class Objects {
 		if (h.type == StreamType.Object) {
 			await w.u53(h.group)
 			await w.u53(h.object)
-			await w.u53(h.priority)
+			await w.u8(h.priority)
 			await w.u53(h.status)
 
 			res = new ObjectWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Group) {
 			await w.u53(h.group)
-			await w.u53(h.priority)
+			await w.u8(h.priority)
 
 			res = new GroupWriter(h, w) as WriterType<T>
 		} else if (h.type === StreamType.Track) {
-			await w.u53(h.priority)
+			await w.u8(h.priority)
 
 			res = new TrackWriter(h, w) as WriterType<T>
 		} else {
@@ -121,7 +121,7 @@ export class Objects {
 				type,
 				sub: await r.u62(),
 				track: await r.u62(),
-				priority: await r.u53(),
+				priority: await r.u8(),
 			}
 
 			res = new TrackReader(h, r)
@@ -131,7 +131,7 @@ export class Objects {
 				sub: await r.u62(),
 				track: await r.u62(),
 				group: await r.u53(),
-				priority: await r.u53(),
+				priority: await r.u8(),
 			}
 			res = new GroupReader(h, r)
 		} else if (type == StreamType.Object) {
@@ -142,7 +142,7 @@ export class Objects {
 				group: await r.u53(),
 				object: await r.u53(),
 				status: await r.u53(),
-				priority: await r.u53(),
+				priority: await r.u8(),
 			}
 
 			res = new ObjectReader(h, r)

--- a/lib/transport/publisher.ts
+++ b/lib/transport/publisher.ts
@@ -86,7 +86,7 @@ export class Publisher {
 		this.#subscribe.set(msg.id, subscribe)
 		await this.#subscribeQueue.push(subscribe)
 
-		await this.#control.send({ kind: Control.Msg.SubscribeOk, id: msg.id, expires: 0n })
+		await this.#control.send({ kind: Control.Msg.SubscribeOk, id: msg.id, expires: 0n, group_order: msg.group_order })
 	}
 
 	recvUnsubscribe(_msg: Control.Unsubscribe) {
@@ -156,6 +156,8 @@ export class SubscribeRecv {
 	#objects: Objects
 	#id: bigint
 	#trackId: bigint
+	#subscriberPriority: number
+	groupOrder: Control.GroupOrder
 
 	readonly namespace: string
 	readonly track: string
@@ -170,6 +172,8 @@ export class SubscribeRecv {
 		this.#trackId = msg.trackId
 		this.namespace = msg.namespace
 		this.track = msg.name
+		this.#subscriberPriority = msg.subscriber_priority
+		this.groupOrder = msg.group_order
 	}
 
 	// Acknowledge the subscription as valid.
@@ -178,7 +182,7 @@ export class SubscribeRecv {
 		this.#state = "ack"
 
 		// Send the control message.
-		return this.#control.send({ kind: Control.Msg.SubscribeOk, id: this.#id, expires: 0n })
+		return this.#control.send({ kind: Control.Msg.SubscribeOk, id: this.#id, expires: 0n, group_order: this.groupOrder })
 	}
 
 	// Close the subscription with an error.

--- a/lib/transport/publisher.ts
+++ b/lib/transport/publisher.ts
@@ -86,7 +86,12 @@ export class Publisher {
 		this.#subscribe.set(msg.id, subscribe)
 		await this.#subscribeQueue.push(subscribe)
 
-		await this.#control.send({ kind: Control.Msg.SubscribeOk, id: msg.id, expires: 0n, group_order: msg.group_order })
+		await this.#control.send({
+			kind: Control.Msg.SubscribeOk,
+			id: msg.id,
+			expires: 0n,
+			group_order: msg.group_order,
+		})
 	}
 
 	recvUnsubscribe(_msg: Control.Unsubscribe) {
@@ -182,7 +187,12 @@ export class SubscribeRecv {
 		this.#state = "ack"
 
 		// Send the control message.
-		return this.#control.send({ kind: Control.Msg.SubscribeOk, id: this.#id, expires: 0n, group_order: this.groupOrder })
+		return this.#control.send({
+			kind: Control.Msg.SubscribeOk,
+			id: this.#id,
+			expires: 0n,
+			group_order: this.groupOrder,
+		})
 	}
 
 	// Close the subscription with an error.

--- a/lib/transport/setup.ts
+++ b/lib/transport/setup.ts
@@ -9,6 +9,7 @@ export enum Version {
 	DRAFT_02 = 0xff000002,
 	DRAFT_03 = 0xff000003,
 	DRAFT_04 = 0xff000004,
+	DRAFT_05 = 0xff000005,
 	KIXEL_00 = 0xbad00,
 	KIXEL_01 = 0xbad01,
 }

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -72,6 +72,8 @@ export class Subscriber {
 			trackId: id,
 			namespace,
 			name: track,
+			subscriber_priority: 127, // default to mid value, see: https://github.com/moq-wg/moq-transport/issues/504
+			group_order: Control.GroupOrder.Publisher,
 			location: {
 				mode: "latest_group",
 			},


### PR DESCRIPTION
Hello Mike @englishm , 

With this PR have attempted to add interop support for "/watch" in moq-js with the draft-05 version of [moq-rs](https://github.com/TilsonJoji/englishm-moq-rs) as of commit https://github.com/englishm/moq-rs/commit/bf830f7887dd94ee6f531c5e375ab3fcc32f9043

i.e. moq-pub -> moq-relay <- moq-js (/watch)

Code changes are pending to make  /publish in moq-js work with  draft-05 version of moq-rs , eventually will attempt on the same.