### PR TITLE
feature: play/pause and running promise modified

### DIFF
--- a/lib/playback/backend.ts
+++ b/lib/playback/backend.ts
@@ -67,13 +67,16 @@ export default class Backend {
 		this.send({ config: msg }, msg.video.canvas)
 	}
 
-	async play() {
-		await this.#audio?.context.resume()
+	pause() {
+		this.send({ pause: true })
 	}
 
-	async pause() {
-		this.send({ pause: true })
+	async mute() {
 		await this.#audio?.context.suspend()
+	}
+
+	async unmute() {
+		await this.#audio?.context.resume()
 	}
 
 	init(init: Init) {

--- a/lib/playback/backend.ts
+++ b/lib/playback/backend.ts
@@ -72,6 +72,7 @@ export default class Backend {
 	}
 
 	async pause() {
+		this.send({ pause: true })
 		await this.#audio?.context.suspend()
 	}
 

--- a/lib/playback/backend.ts
+++ b/lib/playback/backend.ts
@@ -71,6 +71,10 @@ export default class Backend {
 		await this.#audio?.context.resume()
 	}
 
+	async pause() {
+		await this.#audio?.context.suspend()
+	}
+
 	init(init: Init) {
 		this.send({ init })
 	}

--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -53,7 +53,6 @@ export class Player {
 		this.#muted = false
 		this.#paused = false
 
-
 		const abort = new Promise<void>((resolve, reject) => {
 			this.#close = resolve
 			this.#abort = reject
@@ -63,7 +62,7 @@ export class Player {
 		this.#running = abort.catch(this.#close)
 
 		this.#run().catch((err) => {
-			console.error('Error in #run():', err)
+			console.error("Error in #run():", err)
 			this.#abort(err)
 		})
 	}
@@ -125,7 +124,7 @@ export class Player {
 	async #trackTask(track: Catalog.Track) {
 		if (!track.namespace) throw new Error("track has no namespace")
 
-		if (this.#paused) return;
+		if (this.#paused) return
 
 		const kind = Catalog.isVideoTrack(track) ? "video" : Catalog.isAudioTrack(track) ? "audio" : "unknown"
 		if (kind == "audio" && this.#muted) return
@@ -188,7 +187,6 @@ export class Player {
 		task.finally(() => {
 			this.#trackTasks.delete(track.name)
 		})
-
 	}
 
 	getCatalog() {
@@ -291,13 +289,12 @@ export class Player {
 	*/
 
 	async play() {
-		if (this.#paused){
+		if (this.#paused) {
 			this.#paused = false
 			this.subscribeFromTrackName(this.#videoTrackName)
 			this.subscribeFromTrackName(this.#audioTrackName)
 			this.#backend.play()
-		}
-		else {
+		} else {
 			this.unsubscribeFromTrack(this.#videoTrackName)
 			this.unsubscribeFromTrack(this.#audioTrackName)
 			this.#backend.pause()

--- a/lib/playback/worker/index.ts
+++ b/lib/playback/worker/index.ts
@@ -30,6 +30,8 @@ class Worker {
 			this.#onInit(msg.init)
 		} else if (msg.segment) {
 			this.#onSegment(msg.segment).catch(console.warn)
+		} else if (msg.pause) {
+			this.#onPause(msg.pause)
 		} else {
 			throw new Error(`unknown message: + ${JSON.stringify(msg)}`)
 		}
@@ -99,6 +101,12 @@ class Worker {
 
 		// We done.
 		await segment.close()
+	}
+
+	#onPause(pause: boolean) {
+		if (this.#video && pause) {
+			this.#video.pause()
+		}
 	}
 }
 

--- a/lib/playback/worker/message.ts
+++ b/lib/playback/worker/message.ts
@@ -76,6 +76,7 @@ export interface ToWorker {
 	// Sent on each init/data stream
 	init?: Init
 	segment?: Segment
+	pause?: boolean
 
 	/*
 	// Sent to control playback

--- a/lib/playback/worker/video.ts
+++ b/lib/playback/worker/video.ts
@@ -40,6 +40,11 @@ export class Renderer {
 		this.#run().catch(console.error)
 	}
 
+	pause() {
+		console.log("pause")
+		this.#waitingForKeyframe = true
+	}
+
 	async #run() {
 		const reader = this.#timeline.frames.pipeThrough(this.#queue).getReader()
 		for (;;) {

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -46,6 +46,17 @@ export default function Watch(props: { name: string }) {
 		usePlayer()?.play().catch(setError)
 	}
 
+	const handlePlayPause = async () => {
+		const player = usePlayer();
+		if (!player) return;
+
+		try {
+		  await player.play();
+		} catch (error) {
+		  setError();
+		}
+	  };
+
 	// The JSON catalog for debugging.
 	const catalog = createMemo(() => {
 		const player = usePlayer()
@@ -115,6 +126,7 @@ export default function Watch(props: { name: string }) {
 						<input type="checkbox" checked={mute()} onChange={handleMuteChange} />
 						<span>Mute</span>
 					</label>
+					<button onClick={handlePlayPause}>{"Play/Pause"}</button>
 				</div>
 			</div>
 			<h3>Debug</h3>


### PR DESCRIPTION
This PR adds the ability to pause and resume playback in the player. 
- Modified the play() method, which toggles between pausing and resuming playback:
- On pause, it unsubscribes from the current audio and video tracks.
- On resume, it resubscribes to the audio and video tracks.
- Adjusted the handling of `this.#running` and the `#runTrack` tasks to allow resubscription after pausing.
- Can now click either the Play/Pause button or directly on the player (canvas) to toggle playback.
![image](https://github.com/user-attachments/assets/edd1c796-fa58-40c2-84f4-6c45364db00a)
