### PR TITLE
Add basic controls to the player

### DIFF
--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -210,6 +210,10 @@ export class Player {
 		return this.#catalog.tracks.filter(Catalog.isAudioTrack).map((track) => track.name)
 	}
 
+	isPaused() {
+		return this.#paused
+	}
+
 	async switchTrack(trackname: string) {
 		const currentTrack = this.getCurrentTrack()
 		if (this.#paused) {

--- a/web/src/components/play-button.tsx
+++ b/web/src/components/play-button.tsx
@@ -6,7 +6,7 @@ export const PlayButton = (props: PlayButtonProps) => {
 	return (
 		<button
 			class="
-				absolute bottom-4 left-4 flex h-4 w-8 items-center justify-center
+				absolute bottom-0 left-4 flex h-4 w-8 items-center justify-center
 				rounded bg-black/70 px-6 py-4 shadow-lg
 				hover:bg-black/80 focus:bg-black/100 focus:outline-none
 			"

--- a/web/src/components/play-button.tsx
+++ b/web/src/components/play-button.tsx
@@ -1,19 +1,28 @@
 type PlayButtonProps = {
-	play: () => void
+	onClick: () => void
+	isPlaying: boolean
 }
 
 export const PlayButton = (props: PlayButtonProps) => {
 	return (
 		<button
 			class="
-				absolute bottom-0 left-4 flex h-4 w-8 items-center justify-center
-				rounded bg-black/70 px-6 py-4 shadow-lg
+				absolute bottom-0 left-4 flex h-8 w-12 items-center justify-center
+				rounded bg-black/70 px-2 py-2 shadow-lg
 				hover:bg-black/80 focus:bg-black/100 focus:outline-none
 			"
-			onClick={() => props.play()}
-			aria-label="Play"
+			onClick={() => void props.onClick()}
+			aria-label={props.isPlaying ? "Pause" : "Play"}
 		>
-			▶
+			{props.isPlaying ? (
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" class="h-6 w-6">
+					<path d="M6 5h4v14H6zM14 5h4v14h-4z" />
+				</svg>
+			) : (
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" class="h-4 w-4">
+					<path d="M3 22v-20l18 10-18 10z" />
+				</svg>
+			)}
 		</button>
 	)
 }

--- a/web/src/components/play-button.tsx
+++ b/web/src/components/play-button.tsx
@@ -1,0 +1,19 @@
+type PlayButtonProps = {
+	play: () => void
+}
+
+export const PlayButton = (props: PlayButtonProps) => {
+	return (
+		<button
+			class="
+				absolute bottom-4 left-4 flex h-4 w-8 items-center justify-center
+				rounded bg-black/70 px-6 py-4 shadow-lg
+				hover:bg-black/80 focus:bg-black/100 focus:outline-none
+			"
+			onClick={() => props.play()}
+			aria-label="Play"
+		>
+			▶
+		</button>
+	)
+}

--- a/web/src/components/track-select.tsx
+++ b/web/src/components/track-select.tsx
@@ -1,0 +1,80 @@
+import { createEffect, createSignal } from "solid-js"
+
+type TrackSelectProps = {
+	trackNum: number
+	getVideoTracks: () => string[] | undefined
+	switchTrack: (track: string) => void
+}
+
+export const TrackSelect = (props: TrackSelectProps) => {
+	const [options, setOptions] = createSignal<string[]>([])
+	const [selectedOption, setSelectedOption] = createSignal<string | undefined>()
+	const [showTracks, setShowTracks] = createSignal(false)
+
+	const handleTrackChange = (track: string) => {
+		setSelectedOption(track)
+		props.switchTrack(track)
+		setShowTracks(false)
+	}
+
+	function updateURLWithTracknumber(trackIndex: number) {
+		const url = new URL(window.location.href)
+		url.searchParams.set("track", trackIndex.toString())
+		window.history.replaceState({}, "", decodeURIComponent(url.toString()))
+	}
+
+	createEffect(() => {
+		const videotracks = props.getVideoTracks()
+		if (!videotracks?.length) return
+
+		setOptions(videotracks)
+
+		const trackNumber = props.trackNum
+
+		if (trackNumber >= 0 && trackNumber < videotracks.length) {
+			const selectedTrack = videotracks[trackNumber]
+			setSelectedOption(selectedTrack)
+			updateURLWithTracknumber(trackNumber)
+		}
+	})
+	return (
+		<>
+			<button
+				class="
+					flex h-4 w-0 items-center justify-center rounded bg-transparent
+					p-4 text-white hover:bg-black/100
+					focus:bg-black/80 focus:outline-none
+				"
+				aria-label="Select Track"
+				onClick={() => setShowTracks((prev) => !prev)}
+			>
+				⚙️
+			</button>
+			{showTracks() && (
+				<ul class="absolute bottom-6 right-0 mt-2 w-40 rounded bg-black/80 p-0 text-white shadow-lg">
+					{options()?.length ? (
+						options().map((option) => (
+							<li
+								role="menuitem"
+								tabIndex={0}
+								class={`flex w-full cursor-pointer items-center justify-between px-4 py-2 hover:bg-black/100 ${
+									selectedOption() === option ? "bg-blue-500 text-white" : ""
+								}`}
+								onClick={() => handleTrackChange(option)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										handleTrackChange(option)
+									}
+								}}
+							>
+								<span>{option}</span>
+							</li>
+						))
+					) : (
+						<li class="cursor-not-allowed px-4 py-2 text-gray-500">No options available</li>
+					)}
+				</ul>
+			)}
+		</>
+	)
+}

--- a/web/src/components/volume.tsx
+++ b/web/src/components/volume.tsx
@@ -1,0 +1,29 @@
+import { createSignal } from "solid-js"
+
+type VolumeButtonProps = {
+	mute: (isMuted: boolean) => void
+}
+
+export const VolumeButton = (props: VolumeButtonProps) => {
+	const [isMuted, setIsMuted] = createSignal(false)
+
+	const toggleMute = () => {
+		const newIsMuted = !isMuted()
+		setIsMuted(newIsMuted)
+		props?.mute(newIsMuted)
+	}
+
+	return (
+		<button
+			class="
+				absolute bottom-4 right-4 flex h-4 w-0 items-center justify-center rounded bg-black/70 p-4
+				text-white shadow-lg hover:bg-black/80
+				focus:bg-black/80 focus:outline-none
+			"
+			onClick={toggleMute}
+			aria-label={isMuted() ? "Unmute" : "Mute"}
+		>
+			{isMuted() ? "🔇" : "🔊"}
+		</button>
+	)
+}

--- a/web/src/components/volume.tsx
+++ b/web/src/components/volume.tsx
@@ -16,8 +16,8 @@ export const VolumeButton = (props: VolumeButtonProps) => {
 	return (
 		<button
 			class="
-				absolute bottom-4 right-4 flex h-4 w-0 items-center justify-center rounded bg-black/70 p-4
-				text-white shadow-lg hover:bg-black/80
+				flex h-4 w-0 items-center justify-center rounded bg-transparent
+				p-4 text-white hover:bg-black/80
 				focus:bg-black/80 focus:outline-none
 			"
 			onClick={toggleMute}

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -3,6 +3,7 @@ import { Player } from "@kixelated/moq/playback"
 import Fail from "./fail"
 import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js"
 import { VolumeButton } from "./volume"
+import { PlayButton } from "./play-button"
 
 export default function Watch(props: { name: string }) {
 	// Use query params to allow overriding environment variables.
@@ -96,6 +97,7 @@ export default function Watch(props: { name: string }) {
 			<Fail error={error()} />
 			<div class="relative aspect-video w-full">
 				<canvas ref={canvas} onClick={play} class="h-full w-full rounded-lg" />
+				<PlayButton play={play} />
 				<VolumeButton mute={mute} />
 			</div>
 			<div class="mt-4 flex flex-col space-y-4">

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -16,7 +16,7 @@ export default function Watch(props: { name: string }) {
 
 	let canvas!: HTMLCanvasElement
 
-	const [usePlayer, setPlayer] = createSignal<Player | undefined>()
+	const [player, setPlayer] = createSignal<Player | undefined>()
 	const [showCatalog, setShowCatalog] = createSignal(false)
 
 	const [options, setOptions] = createSignal<string[]>([])
@@ -35,23 +35,23 @@ export default function Watch(props: { name: string }) {
 	})
 
 	createEffect(() => {
-		const player = usePlayer()
-		if (!player) return
+		const playerInstance = player()
+		if (!playerInstance) return
 
-		onCleanup(() => player.close())
-		player.closed().then(setError).catch(setError)
+		onCleanup(() => playerInstance.close())
+		playerInstance.closed().then(setError).catch(setError)
 	})
 
 	const play = () => {
-		usePlayer()?.play().catch(setError)
+		player()?.play().catch(setError)
 	}
 
 	// The JSON catalog for debugging.
 	const catalog = createMemo(() => {
-		const player = usePlayer()
-		if (!player) return
+		const playerInstance = player()
+		if (!playerInstance) return
 
-		const catalog = player.getCatalog()
+		const catalog = playerInstance.getCatalog()
 		return JSON.stringify(catalog, null, 2)
 	})
 
@@ -62,10 +62,10 @@ export default function Watch(props: { name: string }) {
 	}
 
 	createEffect(() => {
-		const player = usePlayer()
-		if (!player) return
+		const playerInstance = player()
+		if (!playerInstance) return
 
-		const videotracks = player.getVideoTracks()
+		const videotracks = playerInstance.getVideoTracks()
 		setOptions(videotracks)
 
 		if (tracknum >= 0 && tracknum < videotracks.length) {
@@ -78,7 +78,7 @@ export default function Watch(props: { name: string }) {
 	const handleOptionSelectChange = (event: Event) => {
 		const selectedTrack = (event.target as HTMLSelectElement).value
 		setSelectedOption(selectedTrack)
-		void usePlayer()?.switchTrack(selectedTrack)
+		void player()?.switchTrack(selectedTrack)
 
 		const videotracks = options()
 		const trackIndex = videotracks.indexOf(selectedTrack)
@@ -93,7 +93,7 @@ export default function Watch(props: { name: string }) {
 		const muteValue = (event.target as HTMLInputElement).checked
 
 		setMute(muteValue)
-		void usePlayer()?.mute(muteValue)
+		void player()?.mute(muteValue)
 	}
 
 	// NOTE: The canvas automatically has width/height set to the decoded video size.
@@ -104,7 +104,7 @@ export default function Watch(props: { name: string }) {
 			<canvas ref={canvas} onClick={play} class="aspect-video w-full rounded-lg" />
 			<div class="mt-4 flex flex-col space-y-4">
 				<div class="flex items-center space-x-4">
-					<select value={selectedOption() ?? ''} onChange={handleOptionSelectChange}>
+					<select value={selectedOption() ?? ""} onChange={handleOptionSelectChange}>
 						{options()?.length ? (
 							options().map((option) => <option value={option}>{option}</option>)
 						) : (

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -16,6 +16,7 @@ export default function Watch(props: { name: string }) {
 
 	const [error, setError] = createSignal<Error | undefined>()
 	const [player, setPlayer] = createSignal<Player | undefined>()
+	const [isPlaying, setIsPlaying] = createSignal(!player()?.isPaused())
 	const [showCatalog, setShowCatalog] = createSignal(false)
 	const [hovered, setHovered] = createSignal(false)
 	const [showControls, setShowControls] = createSignal(true)
@@ -47,7 +48,17 @@ export default function Watch(props: { name: string }) {
 		const playerInstance = player()
 		if (!playerInstance) return
 
-		player()?.play().catch(setError)
+		if (playerInstance.isPaused()) {
+			playerInstance
+				.play()
+				.then(() => setIsPlaying(true))
+				.catch(setError)
+		} else {
+			playerInstance
+				.play()
+				.then(() => setIsPlaying(false))
+				.catch(setError)
+		}
 	}
 
 	// The JSON catalog for debugging.
@@ -95,7 +106,7 @@ export default function Watch(props: { name: string }) {
 						showControls() ? "opacity-100" : "opacity-0"
 					} absolute bottom-4 flex h-[40px] w-[100%] items-center gap-[4px] rounded transition-opacity duration-200 `}
 				>
-					<PlayButton play={handlePlayPause} />
+					<PlayButton onClick={handlePlayPause} isPlaying={isPlaying()} />
 					<div class="absolute bottom-0 right-4 flex h-[32px] w-fit items-center justify-evenly gap-[4px] rounded bg-black/70 p-2">
 						<VolumeButton mute={mute} />
 						<TrackSelect trackNum={tracknum} getVideoTracks={getVideoTracks} switchTrack={switchTrack} />


### PR DESCRIPTION
This PR adds basic players controls, which addresses issue https://github.com/englishm/moq-js/issues/7.

We're adding a play button, volume button and track selector, replacing the controls that had been sitting below player. Each control is now its own component, and we attempted to move some logic relevant to these new components out of `watch.tsx` and to the respective component files.

<img width="766" alt="Screenshot 2024-11-28 at 12 30 56 PM" src="https://github.com/user-attachments/assets/891b35e5-52d1-4f2f-a096-556298ea4990">

To test these changes:
- [ ] The play button should resume audio (we will add play/pause functionality when https://github.com/englishm/moq-js/pull/9 is merged)
- [ ] The volume button should handle toggling mute
- [ ] The track selector button should open a menu with available tracks, and selecting a track should update the current video track

Additionally, I renamed `usePlayer` to `player` in `watch.tsx`. I think this is a positive change because:  
1. it's idiomatic to name signals after the value they represent (player, setPlayer)
2. ‘use’ is commonly associated with React hooks
3. it reads as a direct reference to the player

All feedback is welcome!