### PR TITLE
feat: add volume control and UI slider

### DIFF
--- a/lib/playback/backend.ts
+++ b/lib/playback/backend.ts
@@ -87,6 +87,10 @@ export default class Backend {
 		this.send({ segment }, segment.stream)
 	}
 
+	setVolume(newVolume: number) {
+		this.#audio?.setVolume(newVolume)
+	}
+
 	async close() {
 		this.#worker.terminate()
 		await this.#audio?.context.close()

--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -312,6 +312,15 @@ export class Player {
 		}
 	}
 
+	async setVolume(newVolume: number) {
+		this.#backend.setVolume(newVolume)
+		if (newVolume == 0 && !this.#muted) {
+			await this.mute(true)
+		} else if (newVolume > 0 && this.#muted) {
+			await this.mute(false)
+		}
+	}
+
 	/*
 	async *timeline() {
 		for (;;) {

--- a/web/src/components/volume.tsx
+++ b/web/src/components/volume.tsx
@@ -8,6 +8,7 @@ type VolumeControlProps = {
 export const VolumeControl = (props: VolumeControlProps) => {
 	const [isMuted, setIsMuted] = createSignal(false)
 	const [currentVolume, setCurrentVolume] = createSignal(1)
+	const [previousVolume, setPreviousVolume] = createSignal(1)
 
 	const toggleMute = () => {
 		const newIsMuted = !isMuted()
@@ -15,11 +16,13 @@ export const VolumeControl = (props: VolumeControlProps) => {
 		props.mute(newIsMuted)
 
 		if (newIsMuted) {
+			setPreviousVolume(currentVolume())
 			props.setVolume(0)
 			setCurrentVolume(0)
 		} else {
-			props.setVolume(1)
-			setCurrentVolume(1)
+			const restoredVolume = previousVolume()
+			setCurrentVolume(restoredVolume)
+			props.setVolume(restoredVolume)
 		}
 	}
 

--- a/web/src/components/volume.tsx
+++ b/web/src/components/volume.tsx
@@ -1,29 +1,63 @@
 import { createSignal } from "solid-js"
 
-type VolumeButtonProps = {
+type VolumeControlProps = {
 	mute: (isMuted: boolean) => void
+	setVolume: (newVolume: number) => void
 }
 
-export const VolumeButton = (props: VolumeButtonProps) => {
+export const VolumeControl = (props: VolumeControlProps) => {
 	const [isMuted, setIsMuted] = createSignal(false)
+	const [currentVolume, setCurrentVolume] = createSignal(1)
 
 	const toggleMute = () => {
 		const newIsMuted = !isMuted()
 		setIsMuted(newIsMuted)
-		props?.mute(newIsMuted)
+		props.mute(newIsMuted)
+
+		if (newIsMuted) {
+			props.setVolume(0)
+			setCurrentVolume(0)
+		} else {
+			props.setVolume(1)
+			setCurrentVolume(1)
+		}
+	}
+
+	const handleVolumeChange = (e: InputEvent & { currentTarget: HTMLInputElement }) => {
+		const volume = parseFloat(e.currentTarget.value)
+		if (volume == 0) {
+			setIsMuted(true)
+		} else {
+			setIsMuted(false)
+		}
+		setCurrentVolume(volume)
+		props.setVolume(volume)
 	}
 
 	return (
-		<button
-			class="
-				flex h-4 w-0 items-center justify-center rounded bg-transparent
-				p-4 text-white hover:bg-black/80
-				focus:bg-black/80 focus:outline-none
-			"
-			onClick={toggleMute}
-			aria-label={isMuted() ? "Unmute" : "Mute"}
-		>
-			{isMuted() ? "🔇" : "🔊"}
-		</button>
+		<div class="flex items-center gap-2">
+			<button
+				class="
+					flex h-4 w-0 items-center justify-center rounded bg-transparent
+					p-4 text-white hover:bg-black/80
+					focus:bg-black/80 focus:outline-none
+				"
+				onClick={toggleMute}
+				aria-label={isMuted() ? "Unmute" : "Mute"}
+			>
+				{isMuted() ? "🔇" : "🔊"}
+			</button>
+
+			<input
+				type="range"
+				min="0"
+				max="1"
+				step="0.1"
+				style={{ padding: "0" }}
+				value={currentVolume()}
+				onInput={handleVolumeChange}
+				class="h-1 w-24 cursor-pointer"
+			/>
+		</div>
 	)
 }

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -2,7 +2,7 @@
 import { Player } from "@kixelated/moq/playback"
 import Fail from "./fail"
 import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js"
-import { VolumeButton } from "./volume"
+import { VolumeControl } from "./volume"
 import { PlayButton } from "./play-button"
 import { TrackSelect } from "./track-select"
 
@@ -34,6 +34,10 @@ export default function Watch(props: { name: string }) {
 
 	const mute = (state: boolean) => {
 		player()?.mute(state).catch(setError)
+	}
+
+	const setVolume = (newVolume: number) => {
+		player()?.setVolume(newVolume).catch(setError)
 	}
 
 	const switchTrack = (track: string) => {
@@ -108,7 +112,7 @@ export default function Watch(props: { name: string }) {
 				>
 					<PlayButton onClick={handlePlayPause} isPlaying={isPlaying()} />
 					<div class="absolute bottom-0 right-4 flex h-[32px] w-fit items-center justify-evenly gap-[4px] rounded bg-black/70 p-2">
-						<VolumeButton mute={mute} />
+						<VolumeControl mute={mute} setVolume={setVolume} />
 						<TrackSelect trackNum={tracknum} getVideoTracks={getVideoTracks} switchTrack={switchTrack} />
 					</div>
 				</div>


### PR DESCRIPTION
- Implements player volume control: unsubscribes from the audio track at volume 0, and resubscribes when volume is raised above 0.
- Adds a UI slider for adjusting the volume interactively.

[Grabación de pantalla desde 2024-12-09 16-38-55.webm](https://github.com/user-attachments/assets/fb693dd7-7695-44a9-b4ee-75d1109993e8)
