### PR TITLE
Improved Pause Functionality

### DIFF
--- a/lib/playback/backend.ts
+++ b/lib/playback/backend.ts
@@ -68,7 +68,11 @@ export default class Backend {
 	}
 
 	pause() {
-		this.send({ pause: true })
+		this.send({ play: false })
+	}
+
+	play() {
+		this.send({ play: true })
 	}
 
 	async mute() {

--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -303,12 +303,13 @@ export class Player {
 				this.subscribeFromTrackName(this.#audioTrackName)
 				await this.#backend.unmute()
 			}
+			this.#backend.play()
 		} else {
+			this.#paused = true
+			this.#backend.pause()
 			await this.unsubscribeFromTrack(this.#videoTrackName)
 			await this.unsubscribeFromTrack(this.#audioTrackName)
 			await this.#backend.mute()
-			this.#backend.pause()
-			this.#paused = true
 		}
 	}
 

--- a/lib/playback/index.ts
+++ b/lib/playback/index.ts
@@ -307,9 +307,10 @@ export class Player {
 		} else {
 			this.#paused = true
 			this.#backend.pause()
-			await this.unsubscribeFromTrack(this.#videoTrackName)
-			await this.unsubscribeFromTrack(this.#audioTrackName)
-			await this.#backend.mute()
+			const mutePromise = this.#backend.mute()
+			const audioPromise = this.unsubscribeFromTrack(this.#audioTrackName)
+			const videoPromise = this.unsubscribeFromTrack(this.#videoTrackName)
+			await Promise.all([mutePromise, audioPromise, videoPromise])
 		}
 	}
 

--- a/lib/playback/worker/index.ts
+++ b/lib/playback/worker/index.ts
@@ -22,7 +22,7 @@ class Worker {
 
 	on(e: MessageEvent) {
 		const msg = e.data as Message.ToWorker
-		console.log("message: ", msg)
+		// console.log("message: ", msg)
 
 		if (msg.config) {
 			this.#onConfig(msg.config)

--- a/lib/playback/worker/index.ts
+++ b/lib/playback/worker/index.ts
@@ -22,6 +22,7 @@ class Worker {
 
 	on(e: MessageEvent) {
 		const msg = e.data as Message.ToWorker
+		console.log("message: ", msg)
 
 		if (msg.config) {
 			this.#onConfig(msg.config)
@@ -30,8 +31,10 @@ class Worker {
 			this.#onInit(msg.init)
 		} else if (msg.segment) {
 			this.#onSegment(msg.segment).catch(console.warn)
-		} else if (msg.pause) {
-			this.#onPause(msg.pause)
+		} else if (msg.play === false) {
+			this.#onPause(msg.play)
+		} else if (msg.play === true) {
+			this.#onPlay(msg.play)
 		} else {
 			throw new Error(`unknown message: + ${JSON.stringify(msg)}`)
 		}
@@ -103,9 +106,15 @@ class Worker {
 		await segment.close()
 	}
 
-	#onPause(pause: boolean) {
-		if (this.#video && pause) {
+	#onPause(play: boolean) {
+		if (this.#video && !play) {
 			this.#video.pause()
+		}
+	}
+
+	#onPlay(play: boolean) {
+		if (this.#video && play) {
+			this.#video.play()
 		}
 	}
 }

--- a/lib/playback/worker/message.ts
+++ b/lib/playback/worker/message.ts
@@ -76,7 +76,7 @@ export interface ToWorker {
 	// Sent on each init/data stream
 	init?: Init
 	segment?: Segment
-	pause?: boolean
+	play?: boolean
 
 	/*
 	// Sent to control playback

--- a/lib/playback/worker/video.ts
+++ b/lib/playback/worker/video.ts
@@ -58,6 +58,7 @@ export class Renderer {
 		const reader = this.#timeline.frames.pipeThrough(this.#queue).getReader()
 		for (;;) {
 			const { value: frame, done } = await reader.read()
+			if (this.#paused) continue
 			if (done) break
 
 			self.requestAnimationFrame(() => {

--- a/lib/playback/worker/video.ts
+++ b/lib/playback/worker/video.ts
@@ -27,10 +27,12 @@ export class Renderer {
 
 	#decoderConfig?: DecoderConfig
 	#waitingForKeyframe: boolean = true
+	#paused: boolean
 
 	constructor(config: Message.ConfigVideo, timeline: Component) {
 		this.#canvas = config.canvas
 		this.#timeline = timeline
+		this.#paused = false
 
 		this.#queue = new TransformStream({
 			start: this.#start.bind(this),
@@ -41,8 +43,15 @@ export class Renderer {
 	}
 
 	pause() {
-		console.log("pause")
+		this.#paused = true
+		this.#decoder.flush().catch((err) => {
+			console.error(err)
+		})
 		this.#waitingForKeyframe = true
+	}
+
+	play() {
+		this.#paused = false
 	}
 
 	async #run() {
@@ -74,8 +83,8 @@ export class Renderer {
 	}
 
 	#transform(frame: Frame) {
-		if (this.#decoder.state === "closed") {
-			console.warn("Decoder is closed. Skipping frame.")
+		if (this.#decoder.state === "closed" || this.#paused) {
+			console.warn("Decoder is closed or paused. Skipping frame.")
 			return
 		}
 

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -5,6 +5,7 @@ import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-j
 import { VolumeButton } from "./volume"
 import { PlayButton } from "./play-button"
 import { TrackSelect } from "./track-select"
+import { promise } from "astro/zod"
 
 export default function Watch(props: { name: string }) {
 	// Use query params to allow overriding environment variables.
@@ -47,17 +48,15 @@ export default function Watch(props: { name: string }) {
 	const handlePlayPause = () => {
 		const playerInstance = player()
 		if (!playerInstance) return
-
-		if (playerInstance.isPaused()) {
-			playerInstance
-				.play()
-				.then(() => setIsPlaying(true))
-				.catch(setError)
-		} else {
-			playerInstance
-				.play()
-				.then(() => setIsPlaying(false))
-				.catch(setError)
+		try {
+			void playerInstance.play()
+			if (playerInstance.isPaused()) {
+				setIsPlaying(false)
+			} else {
+				setIsPlaying(true)
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err : new Error(String(err)))
 		}
 	}
 


### PR DESCRIPTION
Previously, when the pause was sent, the frames already in the queue before the decoder continued to be processed.

In this update:
- Added a flag to skip processing these frames while paused.
- Implemented a decoder flush to clear any remaining frames inside the decoder.
[Grabación de pantalla desde 2024-12-11 11-14-04.webm](https://github.com/user-attachments/assets/bd6dfb1a-4544-4f61-b683-d706bff109fc)
The button is delayed because it waits for the pause promise to finish.