### PR TITLE
Add basic fullscreen support

### DIFF
--- a/web/src/components/fullscreen.tsx
+++ b/web/src/components/fullscreen.tsx
@@ -22,6 +22,16 @@ export const FullscreenButton = () => {
 		document.addEventListener("fullscreenchange", handleFullscreenChange)
 		onCleanup(() => document.removeEventListener("fullscreenchange", handleFullscreenChange))
 	})
+	createEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.code === "KeyF") {
+				toggleFullscreen()
+			}
+		}
+
+		document.addEventListener("keydown", handleKeyDown, false)
+		onCleanup(() => document.removeEventListener("keydown", handleKeyDown))
+	})
 
 	return (
 		<button

--- a/web/src/components/fullscreen.tsx
+++ b/web/src/components/fullscreen.tsx
@@ -1,0 +1,38 @@
+import { createEffect, createSignal, onCleanup } from "solid-js"
+
+export const FullscreenButton = () => {
+	const [isFullscreen, setIsFullscreen] = createSignal(false)
+
+	const toggleFullscreen = () => {
+		const videoElement = document.getElementById("video")
+
+		if (!isFullscreen()) {
+			void videoElement?.requestFullscreen().catch(console.error)
+			setIsFullscreen(true)
+		} else {
+			void document.exitFullscreen()
+			setIsFullscreen(false)
+		}
+	}
+	createEffect(() => {
+		const handleFullscreenChange = () => {
+			setIsFullscreen(!!document.fullscreenElement)
+		}
+
+		document.addEventListener("fullscreenchange", handleFullscreenChange)
+		onCleanup(() => document.removeEventListener("fullscreenchange", handleFullscreenChange))
+	})
+
+	return (
+		<button
+			class="
+				flex h-4 w-4 items-center justify-center rounded bg-transparent
+				p-4 text-white hover:bg-black/80 focus:outline-none
+				"
+			onClick={toggleFullscreen}
+			aria-label={isFullscreen() ? "Exit full screen" : "Full screen"}
+		>
+			{isFullscreen() ? "⇲" : "⛶"}
+		</button>
+	)
+}

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -6,6 +6,7 @@ import { VolumeControl } from "./volume"
 import { PlayButton } from "./play-button"
 import { TrackSelect } from "./track-select"
 import { promise } from "astro/zod"
+import { FullscreenButton } from "./fullscreen"
 
 export default function Watch(props: { name: string }) {
 	// Use query params to allow overriding environment variables.
@@ -84,7 +85,6 @@ export default function Watch(props: { name: string }) {
 	createEffect(() => {
 		if (hovered()) {
 			setShowControls(true)
-			return
 		}
 
 		const timeoutId = setTimeout(() => setShowControls(false), 3000)
@@ -96,11 +96,11 @@ export default function Watch(props: { name: string }) {
 	return (
 		<>
 			<Fail error={error()} />
-			<div class="relative aspect-video w-full">
+			<div class="relative aspect-video w-full" id="video">
 				<canvas
 					ref={canvas}
 					onClick={handlePlayPause}
-					class="h-full w-full rounded-lg"
+					class="h-full w-full rounded-lg object-contain"
 					onMouseEnter={() => setHovered(true)}
 					onMouseLeave={() => setHovered(false)}
 				/>
@@ -113,6 +113,7 @@ export default function Watch(props: { name: string }) {
 					<div class="absolute bottom-0 right-4 flex h-[32px] w-fit items-center justify-evenly gap-[4px] rounded bg-black/70 p-2">
 						<VolumeControl mute={mute} setVolume={setVolume} />
 						<TrackSelect trackNum={tracknum} getVideoTracks={getVideoTracks} switchTrack={switchTrack} />
+						<FullscreenButton />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
#### Simple fullscreen support 

I tagged the canvas's parent div with a [~~ugly~~ "video" id ](https://github.com/Juanmalopezg/moq-js/blob/846badc25067fd6449eb66b65510336ce96be205/web/src/components/watch.tsx#L96) to handle UI controls in fullscreen. We should replace this once we have a custom web component for the entire element and use that instead.

https://github.com/user-attachments/assets/60915325-62a5-4da4-b4a1-edd289e0e6b2