### PR TITLE
Create store for player

### DIFF
--- a/web/src/components/picture-in-picture.tsx
+++ b/web/src/components/picture-in-picture.tsx
@@ -1,11 +1,7 @@
 import { onCleanup } from "solid-js"
 import { state, setState } from "src/store/state"
 
-type PictureInPictureButtonProps = {
-	play: () => void
-}
-
-export const PictureInPictureButton = (props: PictureInPictureButtonProps) => {
+export const PictureInPictureButton = () => {
 	let videoCanvasElement: HTMLElement | null
 	let pipWindow: WindowWithPiP | null
 
@@ -51,7 +47,7 @@ export const PictureInPictureButton = (props: PictureInPictureButtonProps) => {
 					videoCanvasElement.style.width = "100%"
 					videoCanvasElement.style.height = "100%"
 					// @todo add custom controls to the PiP window
-					videoCanvasElement.onclick = () => props.play()
+					videoCanvasElement.onclick = () => state.handlePlayPause()
 
 					handleEnterPip()
 

--- a/web/src/components/play-button.tsx
+++ b/web/src/components/play-button.tsx
@@ -1,9 +1,6 @@
-type PlayButtonProps = {
-	onClick: () => void
-	isPlaying: boolean
-}
+import { state } from "src/store/state"
 
-export const PlayButton = (props: PlayButtonProps) => {
+export const PlayButton = () => {
 	return (
 		<button
 			class="
@@ -11,10 +8,10 @@ export const PlayButton = (props: PlayButtonProps) => {
 				rounded bg-black/70 px-2 py-2 shadow-lg
 				hover:bg-black/80 focus:bg-black/100 focus:outline-none
 			"
-			onClick={() => void props.onClick()}
-			aria-label={props.isPlaying ? "Pause" : "Play"}
+			onClick={state.handlePlayPause}
+			aria-label={state.isPlaying ? "Pause" : "Play"}
 		>
-			{props.isPlaying ? (
+			{state.isPlaying ? (
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" class="h-6 w-6">
 					<path d="M6 5h4v14H6zM14 5h4v14h-4z" />
 				</svg>

--- a/web/src/components/track-select.tsx
+++ b/web/src/components/track-select.tsx
@@ -1,9 +1,8 @@
 import { createEffect, createSignal } from "solid-js"
+import { state } from "src/store/state"
 
 type TrackSelectProps = {
 	trackNum: number
-	getVideoTracks: () => string[] | undefined
-	switchTrack: (track: string) => void
 }
 
 export const TrackSelect = (props: TrackSelectProps) => {
@@ -13,7 +12,7 @@ export const TrackSelect = (props: TrackSelectProps) => {
 
 	const handleTrackChange = (track: string) => {
 		setSelectedOption(track)
-		props.switchTrack(track)
+		state.switchTrack(track)
 		setShowTracks(false)
 	}
 
@@ -24,7 +23,7 @@ export const TrackSelect = (props: TrackSelectProps) => {
 	}
 
 	createEffect(() => {
-		const videotracks = props.getVideoTracks()
+		const videotracks = state.getVideoTracks()
 		if (!videotracks?.length) return
 
 		setOptions(videotracks)

--- a/web/src/components/volume.tsx
+++ b/web/src/components/volume.tsx
@@ -1,11 +1,7 @@
 import { createSignal } from "solid-js"
+import { state } from "src/store/state"
 
-type VolumeControlProps = {
-	mute: (isMuted: boolean) => void
-	setVolume: (newVolume: number) => void
-}
-
-export const VolumeControl = (props: VolumeControlProps) => {
+export const VolumeControl = () => {
 	const [isMuted, setIsMuted] = createSignal(false)
 	const [currentVolume, setCurrentVolume] = createSignal(1)
 	const [previousVolume, setPreviousVolume] = createSignal(1)
@@ -13,16 +9,16 @@ export const VolumeControl = (props: VolumeControlProps) => {
 	const toggleMute = () => {
 		const newIsMuted = !isMuted()
 		setIsMuted(newIsMuted)
-		props.mute(newIsMuted)
+		state.mute(newIsMuted)
 
 		if (newIsMuted) {
 			setPreviousVolume(currentVolume())
-			props.setVolume(0)
+			state.setVolume(0)
 			setCurrentVolume(0)
 		} else {
 			const restoredVolume = previousVolume()
 			setCurrentVolume(restoredVolume)
-			props.setVolume(restoredVolume)
+			state.setVolume(restoredVolume)
 		}
 	}
 
@@ -34,7 +30,7 @@ export const VolumeControl = (props: VolumeControlProps) => {
 			setIsMuted(false)
 		}
 		setCurrentVolume(volume)
-		props.setVolume(volume)
+		state.setVolume(volume)
 	}
 
 	return (

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -90,9 +90,7 @@ export default function Watch(props: { name: string }) {
 					<div class="absolute bottom-0 right-4 flex h-[32px] w-fit items-center justify-evenly gap-[4px] rounded bg-black/70 p-2">
 						<VolumeControl />
 						<TrackSelect trackNum={tracknum} />
-						{"documentPictureInPicture" in window && (
-							<PictureInPictureButton play={state.handlePlayPause} />
-						)}
+						{"documentPictureInPicture" in window && <PictureInPictureButton />}
 						<FullscreenButton />
 					</div>
 				</div>

--- a/web/src/store/state.ts
+++ b/web/src/store/state.ts
@@ -1,0 +1,39 @@
+import { createStore } from "solid-js/store"
+import { Player } from "@kixelated/moq/playback"
+
+export const [state, setState] = createStore({
+	player: null as Player | null,
+	isPlaying: false,
+	setPlayer: (player: Player) => {
+		setState({ player, isPlaying: !player.isPaused() })
+	},
+	handlePlayPause: () => {
+		const playerInstance = state.player
+		if (!playerInstance) return
+		void playerInstance.play()
+		if (playerInstance.isPaused()) {
+			setState({ isPlaying: false })
+		} else {
+			setState({ isPlaying: true })
+		}
+	},
+	switchTrack: (track: string) => {
+		const playerInstance = state.player
+		if (!playerInstance) return
+		void playerInstance.switchTrack(track)
+	},
+	getVideoTracks: () => {
+		const playerInstance = state.player
+		return playerInstance?.getVideoTracks()
+	},
+	mute: (isMuted: boolean) => {
+		const playerInstance = state.player
+		if (!playerInstance) return
+		void playerInstance.mute(isMuted)
+	},
+	setVolume: (newVolume: number) => {
+		const playerInstance = state.player
+		if (!playerInstance) return
+		void playerInstance.setVolume(newVolume)
+	},
+})

--- a/web/src/store/state.ts
+++ b/web/src/store/state.ts
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { Player } from "@kixelated/moq/playback"
+import Player from "moq-player/simple-player"
 
 export const [state, setState] = createStore({
 	player: null as Player | null,


### PR DESCRIPTION
This PR attempts to build a store for the player, its methods, and other related state. This could allows us to more-easily access state from our components, and avoid needless prop-drilling.

To achieve this, we have created `/store/state.ts`. To begin, it will contain these methods/values, which we are taking from `watch.tsx`:
- `player`
- `isPlaying`
- `handlePlayPause`
- `switchTrack`
- `getVideoTracks`
- `mute`
- `setVolume`

These can be imported to each component. State can be used by invoking `state.xxxx` and we can set state by invoking `setState({ xxxx: value })`.
