### PR TITLE
Add Volume, PiP, Fullscreen functionality to web component

### DIFF
--- a/lib/types/global.d.ts
+++ b/lib/types/global.d.ts
@@ -1,0 +1,17 @@
+interface DocumentPictureInPicture {
+	requestWindow: (options: { width: number; height: number }) => Promise<WindowWithPiP>
+	window: Window | null
+}
+
+interface WindowWithPiP extends Window {
+	document: Document
+	close: () => void
+	addEventListener: (type: string, listener: EventListener) => void
+	removeEventListener: (type: string, listener: EventListener) => void
+}
+
+interface Window {
+	documentPictureInPicture?: DocumentPictureInPicture
+}
+
+declare let documentPictureInPicture: DocumentPictureInPicture

--- a/lib/video-moq/control-buttons/fullscreen-button.ts
+++ b/lib/video-moq/control-buttons/fullscreen-button.ts
@@ -1,0 +1,1 @@
+export const FULLSCREEN_BUTTON = `<button id="fullscreen" class="flex h-4 w-0 items-center justify-center rounded bg-transparent p-4 text-white hover:bg-black-100 focus:bg-black-80 focus:outline-none">⛶</button>`

--- a/lib/video-moq/control-buttons/index.ts
+++ b/lib/video-moq/control-buttons/index.ts
@@ -1,0 +1,4 @@
+import { FULLSCREEN_BUTTON } from "./fullscreen-button"
+import { PICTURE_IN_PICTURE_BUTTON } from "./pip-button"
+
+export { FULLSCREEN_BUTTON, PICTURE_IN_PICTURE_BUTTON }

--- a/lib/video-moq/control-buttons/index.ts
+++ b/lib/video-moq/control-buttons/index.ts
@@ -1,4 +1,5 @@
 import { FULLSCREEN_BUTTON } from "./fullscreen-button"
 import { PICTURE_IN_PICTURE_BUTTON } from "./pip-button"
+import { VOLUME_CONTROL } from "./volume-control"
 
-export { FULLSCREEN_BUTTON, PICTURE_IN_PICTURE_BUTTON }
+export { FULLSCREEN_BUTTON, PICTURE_IN_PICTURE_BUTTON, VOLUME_CONTROL }

--- a/lib/video-moq/control-buttons/pip-button.ts
+++ b/lib/video-moq/control-buttons/pip-button.ts
@@ -1,0 +1,9 @@
+import { ENTER_PIP_SVG } from "../icons"
+
+export const PICTURE_IN_PICTURE_BUTTON = window.documentPictureInPicture
+	? `
+		<button id="picture-in-picture" aria-label="Enter picture-in-picture" class="relative flex h-4 w-0 items-center justify-center rounded bg-transparent p-4 text-white hover:bg-black-80 focus:bg-black-80 focus:outline-none">
+			${ENTER_PIP_SVG}
+		</button>
+	`
+	: ""

--- a/lib/video-moq/control-buttons/volume-control.ts
+++ b/lib/video-moq/control-buttons/volume-control.ts
@@ -1,0 +1,15 @@
+export const VOLUME_CONTROL = `
+	<div class="flex items-center gap-2">
+		<button id="volume" aria-label="Unmute" class="flex h-4 w-0 items-center justify-center rounded bg-transparent p-4 text-white hover:bg-black-80 focus:bg-black-80 focus:outline-none">
+			🔇
+		</button>
+		<input
+			id="volume-range"
+			type="range"
+			min="0"
+			max="1"
+			step="0.1"
+			class="h-1 w-24 cursor-pointer"
+		</input>
+	</div>
+`

--- a/lib/video-moq/icons/enter-pip.ts
+++ b/lib/video-moq/icons/enter-pip.ts
@@ -1,0 +1,8 @@
+export const ENTER_PIP_SVG = `<svg xmlns="http://www.w3.org/2000/svg" class="absolute h-4" viewBox="0 0 24 24">
+<g>
+	<path
+		fill="#fff"
+		d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zm-9.5-6L9.457 9.043l2.25 2.25-1.414 1.414-2.25-2.25L6 12.5V7h5.5z"
+	/>
+</g>
+</svg>`

--- a/lib/video-moq/icons/exit-pip.ts
+++ b/lib/video-moq/icons/exit-pip.ts
@@ -1,0 +1,8 @@
+export const EXIT_PIP_SVG = `<svg xmlns="http://www.w3.org/2000/svg" class="absolute h-4" viewBox="0 0 24 24">
+<g>
+	<path
+		fill="#fff"
+		d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zm-1 2h-6v4h6v-4zM6.707 6.293l2.25 2.25L11 6.5V12H5.5l2.043-2.043-2.25-2.25 1.414-1.414z"
+	/>
+</g>
+</svg>`

--- a/lib/video-moq/icons/index.ts
+++ b/lib/video-moq/icons/index.ts
@@ -1,0 +1,6 @@
+import { PLAY_SVG } from "./play-svg"
+import { PAUSE_SVG } from "./pause-svg"
+import { ENTER_PIP_SVG } from "./enter-pip"
+import { EXIT_PIP_SVG } from "./exit-pip"
+
+export { PLAY_SVG, PAUSE_SVG, ENTER_PIP_SVG, EXIT_PIP_SVG }

--- a/lib/video-moq/icons/pause-svg.ts
+++ b/lib/video-moq/icons/pause-svg.ts
@@ -1,0 +1,3 @@
+export const PAUSE_SVG = /*html*/ `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" class="h-6 w-6">
+					<path d="M6 5h4v14H6zM14 5h4v14h-4z" />
+				</svg>`

--- a/lib/video-moq/icons/play-svg.ts
+++ b/lib/video-moq/icons/play-svg.ts
@@ -1,0 +1,3 @@
+export const PLAY_SVG = /*html*/ `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" class="h-4 w-4">
+					<path d="M3 22v-20l18 10-18 10z" />
+				</svg>`

--- a/lib/video-moq/index.ts
+++ b/lib/video-moq/index.ts
@@ -259,6 +259,8 @@ export class VideoMoq extends HTMLElement {
 
 			this.#volumeButton.addEventListener("click", this.toggleMuteEventHandler)
 
+			this.#base.addEventListener("mouseenter", this.onMouseEnterHandler)
+			this.#base.addEventListener("mouseleave", this.onMouseLeaveHandler)
 			this.#canvas.addEventListener("mouseenter", this.onMouseEnterHandler)
 			this.#canvas.addEventListener("mouseleave", this.onMouseLeaveHandler)
 			this.#controls.addEventListener("mouseenter", this.onMouseEnterHandler)

--- a/lib/video-moq/index.ts
+++ b/lib/video-moq/index.ts
@@ -1,4 +1,6 @@
 import Player from "../playback/index"
+import { FULLSCREEN_BUTTON, PICTURE_IN_PICTURE_BUTTON } from "./control-buttons"
+import { ENTER_PIP_SVG, EXIT_PIP_SVG, PAUSE_SVG, PLAY_SVG } from "./icons"
 
 /**
  * This stylesheet is self contained within the shadow root
@@ -6,31 +8,6 @@ import Player from "../playback/index"
  * the document's style.
  */
 import STYLE_SHEET from "./video-moq.css"
-
-const PLAY_SVG = /*html*/ `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" class="h-4 w-4">
-					<path d="M3 22v-20l18 10-18 10z" />
-				</svg>`
-const PAUSE_SVG = /*html*/ `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" class="h-6 w-6">
-					<path d="M6 5h4v14H6zM14 5h4v14h-4z" />
-				</svg>`
-
-const ENTER_PIP_SVG = `<svg xmlns="http://www.w3.org/2000/svg" class="absolute h-4" viewBox="0 0 24 24">
-					<g>
-						<path
-							fill="#fff"
-							d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zm-9.5-6L9.457 9.043l2.25 2.25-1.414 1.414-2.25-2.25L6 12.5V7h5.5z"
-						/>
-					</g>
-				</svg>`
-
-const EXIT_PIP_SVG = `<svg xmlns="http://www.w3.org/2000/svg" class="absolute h-4" viewBox="0 0 24 24">
-					<g>
-						<path
-							fill="#fff"
-							d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zm-1 2h-6v4h6v-4zM6.707 6.293l2.25 2.25L11 6.5V12H5.5l2.043-2.043-2.25-2.25 1.414-1.414z"
-						/>
-					</g>
-				</svg>`
 
 export class VideoMoq extends HTMLElement {
 	private shadow: ShadowRoot
@@ -248,13 +225,6 @@ export class VideoMoq extends HTMLElement {
 
 		if (this.controls !== null) {
 			const controlsElement = document.createElement("div")
-			const pipButtonHTML = window.documentPictureInPicture
-				? `
-					<button id="picture-in-picture" aria-label="Enter picture-in-picture" class="relative flex h-4 w-0 items-center justify-center rounded bg-transparent p-4 text-white hover:bg-black-80 focus:bg-black-80 focus:outline-none">
-						${ENTER_PIP_SVG}
-					</button>
-				`
-				: ""
 			controlsElement.innerHTML = /* html */ `
 			<div id="controls" class="absolute opacity-0 bottom-4 flex h-[40px] w-full items-center gap-[4px] rounded transition-opacity duration-200" >
 				<button id="play" class="absolute bottom-0 left-4 flex h-8 w-12 items-center justify-center rounded bg-black-70 px-2 py-2 shadow-lg hover:bg-black-80 focus:bg-black-100 focus:outline-none">
@@ -269,10 +239,8 @@ export class VideoMoq extends HTMLElement {
 					</button>
 					<ul id="tracklist" class="absolute bottom-6 right-0 mt-2 w-40 rounded bg-black-80 p-0 text-white shadow-lg">
 					</ul>
-					${pipButtonHTML}
-					<button id="fullscreen" class="flex h-4 w-0 items-center justify-center rounded bg-transparent p-4 text-white hover:bg-black-100 focus:bg-black-80 focus:outline-none">
-						⛶
-					</button>
+					${PICTURE_IN_PICTURE_BUTTON}
+					${FULLSCREEN_BUTTON}
 				</div>
 			</div>`
 			this.#base.appendChild(controlsElement.children[0])

--- a/lib/video-moq/video-moq.css
+++ b/lib/video-moq/video-moq.css
@@ -5,6 +5,7 @@
 canvas#canvas {
 	z-index: 0;
 	background: rgb(28, 28, 28);
+	object-fit: contain;
 }
 
 #controls {

--- a/lib/video-moq/video-moq.css
+++ b/lib/video-moq/video-moq.css
@@ -23,6 +23,11 @@ canvas#canvas {
 #controls {
 	z-index: 10;
 }
+
+#controls:focus-within {
+	opacity: 1;
+}
+
 #controls button {
 	cursor: pointer;
 }

--- a/lib/video-moq/video-moq.css
+++ b/lib/video-moq/video-moq.css
@@ -2,6 +2,18 @@
  each element in dev tools and cleaned up some classes.
  Feel free to modify. */
 
+#base {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+#base.pip-mode {
+	background-color: rgb(0, 0, 0);
+	height: 100%;
+}
+
 canvas#canvas {
 	z-index: 0;
 	background: rgb(28, 28, 28);

--- a/samples/web-component-advanced/web-component-module-advanced.html
+++ b/samples/web-component-advanced/web-component-module-advanced.html
@@ -9,14 +9,14 @@
 		<h1>Web Component Advanced Example</h1>
 		<!-- Using the script player component -->
 
-		<div id="video-moq" style="width: 640px"></div>
+		<div id="video-moq" style="width: 640px; height: 360px"></div>
 		<script type="module">
 			import VideoMoq from "/moq-player/moq-player.esm.js";
 
 			var video = document.getElementById("video-moq");
 			var videoSrc = "https://localhost:4443?namespace=bbb&fingerprint=https://localhost:4443/fingerprint";
 
-			var player = new VideoMoq(video);
+			var player = new VideoMoq();
 			player.src = videoSrc;
 			player.trackNum = 0;
 			player.controls = true;

--- a/samples/web-component-advanced/web-component-module-advanced.html
+++ b/samples/web-component-advanced/web-component-module-advanced.html
@@ -16,7 +16,7 @@
 			var video = document.getElementById("video-moq");
 			var videoSrc = "https://localhost:4443?namespace=bbb&fingerprint=https://localhost:4443/fingerprint";
 
-			var player = new VideoMoq();
+			var player = new VideoMoq(video);
 			player.src = videoSrc;
 			player.trackNum = 0;
 			player.controls = true;

--- a/samples/web-component-basic/web-component-basic.html
+++ b/samples/web-component-basic/web-component-basic.html
@@ -14,6 +14,7 @@
 			src="https://localhost:4443?namespace=bbb"
 			fingerprint="https://localhost:4443/fingerprint"
 			width="640px"
+			height="360px"
 			controls
 		></video-moq>
 	</body>


### PR DESCRIPTION
This PR adds functionality for more-granular volume control, picture-and-picture and fullscreen to the video-moq web component. This logic was recently added to `/web`, so I thought it would be cool to see this in action with our new web component.

## Demo
Demo link for PiP and Fullscreen behavior: https://vimeo.com/1048136181/2c86f80456?share=copy

<img width="656" alt="Screenshot 2025-01-19 at 11 11 23 PM" src="https://github.com/user-attachments/assets/b06f6940-6371-4079-8dc3-f1fa12dc406a" />

## New Folder Structure
I also took a little bit of time to try and create a folder structure to store our icons and control-buttons, so you will see the new buttons imported from `control-buttons`.

The new folders introduced:
- `lib/video-moq/control-buttons`
- `lib-video-moq/icons`

## Possible next steps
On Discord, @englishm mentioned that it would be cool to see us get media-chrome to work with the web component, so that could be a cool next step, as we work towards consolidating and reducing duplicated logic.

## Testing: 
- [x] Clicking on the picture-in-picture button should move the canvas to a picture-in-picture window using the DocumentPictureInPicture API
- [x] Clicking on the picture-in-picture button when the PiP window is active should move the canvas back to the base container, and close the PiP window.

- [x] Clicking on the fullscreen button should move the canvas to full screen
- [x] Clicking on the fullscreen button again should restore the canvas
- [x] Keydown on 'f' should move the canvas to full screen
- [x] Keydown on 'f' when in full screen should restore the canvas

- [x] Volume slider should set volume to new value
- [x] Clicking on mute should set volume slider to 0
- [x] Clicking on unmute should set volume to previously-set volume

- [x] The controls should not disappear if any button has keyboard focus