### PR TITLE
fetch control messages

### DIFF
--- a/lib/transport/client.ts
+++ b/lib/transport/client.ts
@@ -45,12 +45,21 @@ export class Client {
 		const reader = new Stream.Reader(new Uint8Array(), stream.readable)
 
 		const setup = new Setup.Stream(reader, writer)
+		console.log("client.ts connect() setup: role, versions: ", this.config.role, [Setup.Version.DRAFT_06])
 
-		// Send the setup message.
-		await setup.send.client({
+		const setupPayload: Setup.Client = {
 			versions: [Setup.Version.DRAFT_06],
 			role: this.config.role,
-		})
+		}
+
+		if (this.config.role === "publisher") {
+			// @todo: pass in maxSubscribeID so this is dynamic
+			console.log("~~~adding maxSubscribeID to setupPayload")
+			setupPayload.params = new Map<bigint, Uint8Array>().set(2n, new Uint8Array([2]))
+		}
+
+		// Send the setup message.
+		await setup.send.client(setupPayload)
 
 		// Receive the setup message.
 		// TODO verify the SETUP response.

--- a/lib/transport/publisher.ts
+++ b/lib/transport/publisher.ts
@@ -16,6 +16,9 @@ export class Publisher {
 	#subscribe = new Map<bigint, SubscribeRecv>()
 	#subscribeQueue = new Queue<SubscribeRecv>(Number.MAX_SAFE_INTEGER) // Unbounded queue in case there's no receiver
 
+	// Their subscribed namespaces.
+	#subscribeNamespace = new Map<string, bigint>()
+
 	constructor(control: Control.Stream, objects: Objects) {
 		this.#control = control
 		this.#objects = objects
@@ -52,6 +55,10 @@ export class Publisher {
 			this.recvAnnounceOk(msg)
 		} else if (msg.kind == Control.Msg.AnnounceError) {
 			this.recvAnnounceError(msg)
+		} else if (msg.kind == Control.Msg.SubscribeNamespace) {
+			this.recvSubscribeNamespace(msg)
+		} else if (msg.kind == Control.Msg.UnsubscribeNamespace) {
+			this.recvUnsubscribeNamespace(msg)
 		} else {
 			throw new Error(`unknown control message`) // impossible
 		}
@@ -95,7 +102,15 @@ export class Publisher {
 	}
 
 	recvUnsubscribe(_msg: Control.Unsubscribe) {
-		throw new Error("TODO unsubscribe")
+		throw new Error("TODO Unsubscribe")
+	}
+
+	recvSubscribeNamespace(_msg: Control.SubscribeNamespace) {
+		throw new Error("TODO SubscribeNamespace")
+	}
+
+	recvUnsubscribeNamespace(_msg: Control.UnsubscribeNamespace) {
+		throw new Error("TODO UnsubscribeNamespace")
 	}
 }
 

--- a/lib/transport/publisher.ts
+++ b/lib/transport/publisher.ts
@@ -19,6 +19,9 @@ export class Publisher {
 	// Their subscribed namespaces.
 	#subscribeNamespace = new Map<string, bigint>()
 
+	// Maximum Subscription ID allowed.
+	#maxSubscribeId = Infinity
+
 	constructor(control: Control.Stream, objects: Objects) {
 		this.#control = control
 		this.#objects = objects
@@ -82,6 +85,12 @@ export class Publisher {
 		}
 
 		announce.onError(msg.code, msg.reason)
+	}
+
+	checkSubscribeId(id: bigint) {
+		if (id > this.#maxSubscribeId) {
+			throw new Error(`subscribe id too large: ${id} > ${this.#maxSubscribeId} max subscribe id`)
+		}
 	}
 
 	async recvSubscribe(msg: Control.Subscribe) {

--- a/lib/transport/setup.ts
+++ b/lib/transport/setup.ts
@@ -69,6 +69,7 @@ export class Decoder {
 
 		const params = await this.parameters()
 		const role = this.role(params?.get(0n))
+		console.log("setup.ts Decoder.client() params:", params)
 
 		return {
 			versions,
@@ -88,7 +89,7 @@ export class Decoder {
 
 		const version = await this.r.u53()
 		const params = await this.parameters()
-
+		console.log("setup.ts Decoder.server() params:", params)
 		return {
 			version,
 			params,

--- a/lib/transport/subscriber.ts
+++ b/lib/transport/subscriber.ts
@@ -40,6 +40,10 @@ export class Subscriber {
 			await this.recvSubscribeError(msg)
 		} else if (msg.kind == Control.Msg.SubscribeDone) {
 			await this.recvSubscribeDone(msg)
+		} else if (msg.kind == Control.Msg.SubscribeNamespaceOk) {
+			this.recvSubscribeNamespaceOk(msg)
+		} else if (msg.kind == Control.Msg.SubscribeNamespaceError) {
+			this.recvSubscribeNamespaceError(msg)
 		} else {
 			throw new Error(`unknown control message`) // impossible
 		}
@@ -129,6 +133,14 @@ export class Subscriber {
 		}
 
 		await subscribe.onError(msg.code, msg.reason)
+	}
+
+	recvSubscribeNamespaceOk(_msg: Control.SubscribeNamespaceOk) {
+		throw new Error(`TODO SubscribeNamespaceOk`)
+	}
+
+	recvSubscribeNamespaceError(_msg: Control.SubscribeNamespaceError) {
+		throw new Error(`TODO SubscribeNamespaceError`)
 	}
 
 	async recvObject(reader: TrackReader | SubgroupReader) {


### PR DESCRIPTION
This PR implements support for the FETCH control message, as specified in the MoQ Transport draft-07. It includes both the encoder and decoder for FETCH, FETCH_CANCEL, FETCH_OK, and FETCH_ERROR messages. 