### PR TITLE
Publish release packages to npm registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: publish package
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: cp README.md lib/README.md
+      - working-directory: lib
+        run: |
+          npm ci
+          npm run build
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ This library offers **two main approaches** to playing MoQ streams in a browser:
 Install the library from npm:
 
 ```bash
-npm install moq-player
+npm install @moq-js/player
 ```
 
 Or include via a `<script>` tag (for the IIFE build):
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/package@latest/dist/moq-player.iife.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@moq-js/player@latest/dist/moq-player.iife.js"></script>
 ```
 
 ## Usage

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,10 +1,11 @@
 {
-	"name": "moq-player",
-	"version": "0.0.1",
+	"name": "@moq-js/player",
+	"version": "0.2.0",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"wc-player": "video-moq/index.ts",
 	"simple-player": "playback/index.ts",
+	"files": ["dist"],
 	"exports": {
 		".": {
 			"import": "./dist/moq-player.esm.js",
@@ -69,5 +70,9 @@
 			"last 1 firefox version",
 			"last 1 safari version"
 		]
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/~englishm/moq-js"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
 	"name": "moq-js",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -15,8 +16,8 @@
 			}
 		},
 		"lib": {
-			"name": "moq-player",
-			"version": "0.0.1",
+			"name": "@moq-js/player",
+			"version": "0.2.0",
 			"license": "(MIT OR Apache-2.0)",
 			"dependencies": {
 				"mp4box": "^0.5.2"
@@ -2452,6 +2453,10 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/@moq-js/player": {
+			"resolved": "lib",
+			"link": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "moq-js",
 	"type": "module",
-	"private": true,
 	"workspaces": [
 		"lib",
 		"web",


### PR DESCRIPTION
As discussed in #31 and  #36 , this PR adds a GitHub Actions workflow that publishes a new release package to the https://www.npmjs.com/org/moq-js npm repository. This enables distribution via:

```
npm i @moq-js/player
```


> [!NOTE]
> I tested this behaviour by publishing to https://www.npmjs.com/package/@juanmanulpzg/player. Please check [this temp commit in my fork repo](https://github.com/englishm/moq-js/commit/80c93f09ec4000cef487166a637045516c854d8b) to see the only differences compared to the current PR changes.

Considerations:

- The workflow is triggered when a release is published in the https://github.com/englishm/moq-js repository (not on each main branch update).
- Each new release should include an updated version field in package.json.

Feel free to suggest any improvements to these changes ✨