### PR TITLE
Fix build step and SubscribeDone handling

### DIFF
--- a/lib/contribute/container.ts
+++ b/lib/contribute/container.ts
@@ -72,7 +72,7 @@ export class Container {
 		}
 
 		this.#track = this.#mp4.addTrack(options)
-		if (!this.#track) throw new Error("failed to initialize MP4 track")
+		if (!this.#track || !this.#mp4.ftyp || !this.#mp4.moov) throw new Error("failed to initialize MP4 track")
 
 		const buffer = MP4.ISOFile.writeInitializationSegment(this.#mp4.ftyp, this.#mp4.moov, 0, 0)
 		const data = new Uint8Array(buffer)

--- a/lib/media/mp4/index.ts
+++ b/lib/media/mp4/index.ts
@@ -27,6 +27,8 @@ MP4.BoxParser.dOpsBox.prototype.write = function (stream: MP4.Stream) {
 	stream.writeInt16(this.OutputGain)
 	stream.writeUint8(this.ChannelMappingFamily)
 
+	if (!this.StreamCount || !this.CoupledCount) throw new Error("failed to write dOps box")
+
 	if (this.ChannelMappingFamily !== 0) {
 		stream.writeUint8(this.StreamCount)
 		stream.writeUint8(this.CoupledCount)

--- a/lib/transport/control.ts
+++ b/lib/transport/control.ts
@@ -309,6 +309,7 @@ export class Decoder {
 			case Msg.SubscribeError:
 				return this.subscribe_error()
 			case Msg.SubscribeDone:
+				return this.subscribe_done()
 			case Msg.Unsubscribe:
 				return this.unsubscribe()
 			case Msg.Announce:


### PR DESCRIPTION
This PR fixes the build step where the `@rollup/typescript` plugin was [failing to compile](https://github.com/englishm/moq-js/actions/runs/13509906972/job/37747836809). This should fix the npm publish step so the [jsdelivr](https://cdn.jsdelivr.net/npm/@moq-js-ci-test/moq-js@latest/dist/moq-player.iife.js) source stays up to date with the latest releases.

I noticed another issue while testing locally that track switching and muting would crash the player.  Looks like the `SubscribeDone` handler was inadvertently removed and the message was falling through to our unimplemented `Unsubscribe` publisher message handler.