### PR TITLE
Bump lib version to fix publish

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moq-js/player",
-	"version": "0.2.2",
+	"version": "0.4.3",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"wc-player": "video-moq/index.ts",


### PR DESCRIPTION
It turns out that the publish step has been failing because the library version hasn't been getting bumped.

I'll look into adding an auto bump to the github action, but this will get things working in the meantime.

![image](https://github.com/user-attachments/assets/5092d1cc-a36a-4403-b295-3420ac51d696)
